### PR TITLE
Respecting id flag passed in that causes field value to be wrapped in ObjectID

### DIFF
--- a/lib/join.js
+++ b/lib/join.js
@@ -166,20 +166,20 @@ var Join = function Join(client) {
       return fn(null, null);
     }  
 
-    if(join.id && util.isArray(doc[join.field])) {
+    if(util.isArray(doc[join.field])) {
 
       if(doc[join.field].length > 1) {
         val = {'$in': []};
         for(var i=0; i<doc[join.field].length; i++) {
-          val['$in'].push(new ObjectID(doc[join.field][i]));
+          val['$in'].push(join.id ? new ObjectID(doc[join.field][i]) : doc[join.field][i]);
         }
 
         queryType = 'find';
       } else {
-        val = doc[join.field][0];
+        val = join.id ? new ObjectID(doc[join.field][0]) : doc[join.field][0];
       }
     } else {
-        val = doc[join.field];
+      val = join.id ? new ObjectID(doc[join.field]) : doc[join.field];
     }
 
     if (!val) return fn(null, null); // no doc match, i.e. this doc doesn't have the 'on' field.


### PR DESCRIPTION
There is a bug in your implementation - when joining on a single field, it should respect join.id and wrap the value in ObjectID.
