### PR TITLE
Doing a find in query even if there is one item in the list

### DIFF
--- a/lib/join.js
+++ b/lib/join.js
@@ -167,17 +167,12 @@ var Join = function Join(client) {
     }  
 
     if(join.id && util.isArray(doc[join.field])) {
-
-      if(doc[join.field].length > 1) {
-        val = {'$in': []};
-        for(var i=0; i<doc[join.field].length; i++) {
-          val['$in'].push(new ObjectID(doc[join.field][i]));
-        }
-
-        queryType = 'find';
-      } else {
-        val = doc[join.field][0];
+      val = {'$in': []};
+      for(var i=0; i<doc[join.field].length; i++) {
+        val['$in'].push(new ObjectID(doc[join.field][i]));
       }
+
+      queryType = 'find';
     } else {
         val = doc[join.field];
     }


### PR DESCRIPTION
When joining a list with another collection, if there is only one item, currently it replaces the whole list with the joined item. It's my view that it is not reasonable to do this as there are plenty of assumptions made about the shape of the document, i.e. consumers of the data expect it to be a list.

It doesn't provide much convenience to just return the item instead of a singleton list. Let's just not.
